### PR TITLE
Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/core/res/res/values/ancient_strings.xml
+++ b/core/res/res/values/ancient_strings.xml
@@ -43,4 +43,8 @@
     <string name="url_copy_success">URL copied successfully</string>
     <string name="url_copy_failed">An error occured while uploading the log to dogbin</string>
 
+    <!-- Full screen aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
+    <item name="config_screenAspectRatio" format="float" type="dimen">2.1</item>
+
 </resources>

--- a/core/res/res/values/ancient_symbols.xml
+++ b/core/res/res/values/ancient_symbols.xml
@@ -198,4 +198,8 @@
     <java-symbol type="id" name="aerr_copy" />
     <java-symbol type="string" name="url_copy_success" />
     <java-symbol type="string" name="url_copy_failed" />
+
+    <!-- Full screen aspect ratio -->
+    <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
+    <java-symbol type="dimen" name="config_screenAspectRatio" />
 </resources>

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -177,6 +177,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.res.CompatibilityInfo;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.GraphicBuffer;
 import android.graphics.Rect;
@@ -421,6 +422,12 @@ final class ActivityRecord extends ConfigurationContainer {
 
     // Token for targeting this activity for assist purposes.
     final Binder assistToken = new Binder();
+
+    private final float mFullScreenAspectRatio = Resources.getSystem().getFloat(
+                    com.android.internal.R.dimen.config_screenAspectRatio);
+
+    private final boolean higherAspectRatio = Resources.getSystem().getBoolean(
+            com.android.internal.R.bool.config_haveHigherAspectRatioScreen);
 
     private static String startingWindowStateToString(int state) {
         switch (state) {
@@ -2797,10 +2804,14 @@ final class ActivityRecord extends ConfigurationContainer {
 
         // The rest of the condition is that only one side is smaller than the parent, but it still
         // needs to exclude the cases where the size is limited by the fixed aspect ratio.
-        if (info.maxAspectRatio > 0) {
+        float maxAspectRatio = (higherAspectRatio && appInfo.targetSdkVersion
+                             < android.os.Build.VERSION_CODES.O) ? mFullScreenAspectRatio
+                             : info.maxAspectRatio;
+
+        if (maxAspectRatio > 0) {
             final float aspectRatio = (0.5f + Math.max(appWidth, appHeight))
                     / Math.min(appWidth, appHeight);
-            if (aspectRatio >= info.maxAspectRatio) {
+            if (aspectRatio >= maxAspectRatio) {
                 // The current size has reached the max aspect ratio.
                 return false;
             }
@@ -3068,7 +3079,11 @@ final class ActivityRecord extends ConfigurationContainer {
     // TODO(b/36505427): Consider moving this method and similar ones to ConfigurationContainer.
     private void computeBounds(Rect outBounds, Rect containingAppBounds) {
         outBounds.setEmpty();
-        final float maxAspectRatio = info.maxAspectRatio;
+
+        final float maxAspectRatio = (higherAspectRatio && appInfo.targetSdkVersion
+                             < android.os.Build.VERSION_CODES.O) ? mFullScreenAspectRatio
+                             : info.maxAspectRatio;
+
         final ActivityStack stack = getActivityStack();
         final float minAspectRatio = info.minAspectRatio;
 


### PR DESCRIPTION
When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change default
aspect ratio for pre-O apps to 2.1 which would fit recent devices.

Wight554:
Simplify the code, we don't need the Settings for that, just bool

@sagarmakhar:
apply settings only on apps targetting sdk version less than oreo

Change-Id: I1ff5998e3a3429bfb9429674b4fe504d0b6ec025
Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>