### PR TITLE
SystemUI: Fix SystemUI failed to go to doze issue

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4412,6 +4412,7 @@ public class StatusBar extends SystemUI implements DemoMode,
 
         @Override
         public void onScreenTurnedOff() {
+            updateDozing();
             mFalsingManager.onScreenOff();
             mScrimController.onScreenTurnedOff();
             mVisualizerView.setVisible(false);
@@ -4979,6 +4980,8 @@ public class StatusBar extends SystemUI implements DemoMode,
                 DozeLog.traceDozing(mContext, mDozing);
                 updateDozing();
                 updateIsKeyguard();
+            } else {
+                mDozingRequested = true;
             }
         }
 


### PR DESCRIPTION
DozeService is started before screen turned off, which leads
SystemUI to go to doze failed. SystemUI doesn't request turn
on screen when receiving new message.

In this case, SystemUI updates doze state after screen turned
off, so that SystemUI can go to doze.

Change-Id: Ib4386301f2f0b1ea1c349346b5d7894aeca37abf
CRs-Fixed: 2468758
Signed-off-by: NurKeinNeid <mralexman3000@gmail.com>
Signed-off-by: Joey Huab <joey@evolution-x.org>
Signed-off-by: Shubham <skpawar1305@gmail.com>