### PR TITLE
Skip screen on animation when wake and unlock via biometrics

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4891,7 +4891,8 @@ public class StatusBar extends SystemUI implements DemoMode,
 
         boolean launchingAffordanceWithPreview =
                 mNotificationPanel.isLaunchingAffordanceWithPreview();
-        mScrimController.setLaunchingAffordanceWithPreview(launchingAffordanceWithPreview);
+        mScrimController.setLaunchingAffordanceWithPreview(launchingAffordanceWithPreview
+                || mBiometricUnlockController.isWakeAndUnlock());
 
         if (mBouncerShowing) {
             // Bouncer needs the front scrim when it's on top of an activity,


### PR DESCRIPTION
Screen on animation is slow. Modern fingerprint sensor is *FAST*.
We need moar speed to deliver better user experience.

* OEMs are doing this for years.

Change-Id: I5f98259eb992b2f43872f957fcb0092412fe558c